### PR TITLE
Use a const ConcurrentDict from ConcurrentCollections as module level variable

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,6 +4,7 @@ author = ["Luke Stagner <stagnerl@fusion.gat.com>"]
 version = "0.1.0"
 
 [deps]
+ConcurrentCollections = "5060bff5-0b44-40c5-b522-fcd3ca5cecdd"
 Contour = "d38c429a-6771-53c6-b99e-75d170b6e991"
 EFIT = "cda752c5-6b03-55a3-9e33-132a441b0c17"
 ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"

--- a/src/Equilibrium.jl
+++ b/src/Equilibrium.jl
@@ -2,6 +2,7 @@ __precompile__()
 
 module Equilibrium
 
+using ConcurrentCollections
 using EFIT
 using LinearAlgebra
 using Interpolations

--- a/src/solovev.jl
+++ b/src/solovev.jl
@@ -570,7 +570,7 @@ function psi_gradient(S::SolovevEquilibrium,r,z)
     return (S.psi0/R0)*SVector{2}(_solovev_psi_Dx(x,y,S.alpha,S.c; logx=logx), _solovev_psi_Dy(x,y,S.alpha,S.c;logx=logx))
 end
 
-_solovev_magnetic_axis = Dict{SolovevEquilibrium,NTuple{2}}()
+const _solovev_magnetic_axis = ConcurrentDict{SolovevEquilibrium,NTuple{2}}()
 function clear_cache(S)
     delete!(_solovev_magnetic_axis,S)
 end


### PR DESCRIPTION
I've swapped out the `_solovev_magnetic_axis` dictionary for a `const` dictionary from `ConncurrentCollections`. Hopefully, this makes the package thread-safe; I have occasionally encountered errors when accessing this dictionary.