### PR TITLE
Fixed bug in shape.jl/scale_aspect()

### DIFF
--- a/src/shape.jl
+++ b/src/shape.jl
@@ -6,8 +6,9 @@ major_radius(S::PlasmaShape) = S.R0
 minor_radius(S::PlasmaShape) = S.R0*S.ϵ
 
 function scale_aspect(S::PlasmaShape,s)
-    SS = copy(S)
+    SS = deepcopy(S)
     SS.ϵ = s*S.ϵ
+    return SS
 end
 
 """


### PR DESCRIPTION
Simply changing `copy()` to `deepcopy()` in the `scale_aspect()` function fixes the issue. Since the `scale_aspect()` function is not to be used in repetetive calls (e.g. for-loops), the performance impact of using `deepcopy()` instead of `copy()` is negligible.